### PR TITLE
Rymichael/merge multiple logs support skew

### DIFF
--- a/py/strato/common/log/log2text.py
+++ b/py/strato/common/log/log2text.py
@@ -197,6 +197,7 @@ if __name__ == "__main__":
     parser.add_argument("--withThreads", action="store_true", help='print process and thread name')
     parser.add_argument("-f", "--follow", action="store_true", help='follow file forever', default=False)
     parser.add_argument("-l", "--localtime", action="store_true", help='print logs in localtime (default utc)', default=False)
+    parser.add_argument("--freeFormat", action="store_true", help='support log files not in Stratoscale format')
     args = parser.parse_args()
 
     if _runningInATerminal and not args.noLess:
@@ -214,7 +215,7 @@ if __name__ == "__main__":
         sys.exit(0)
     signal.signal(signal.SIGINT, _exitOrderlyOnCtrlC)
 
-    if len(args.logFiles) == 1:
-        printLog(logFile=args.logFiles[0], formatter=formatter, follow=args.follow)
-    else:
+    if len(args.logFiles) > 1 or args.freeFormat:
         printLogs(logFiles=args.logFiles, formatter=formatter)
+    elif len(args.logFiles) == 1:
+        printLog(logFile=args.logFiles[0], formatter=formatter, follow=args.follow)


### PR DESCRIPTION
@rom-stratoscale Supporting skew definition on logs by using curl attribute style notation, like: consul.log?skew=-1h
or
strato-log consul.log?skew=-1h clusterd.stratolog?skew=-1h0m10s
The skew parameter is not required and can be omitted.
It is more simple notation than my initial proposal with json. Shall not be very difficult to use it.
The code is not tested enough yet.