### PR TITLE
SI-369 - replacing percent signs with escaped versions of it in logs …

### DIFF
--- a/py/strato/common/log/log2text.py
+++ b/py/strato/common/log/log2text.py
@@ -59,7 +59,7 @@ class Formatter:
     def process(self, obj):
         if obj['levelno'] < self._minimumLevel:
             return None
-        if 'args' in obj:
+        if 'args' in obj and obj['args']:
             if isinstance(obj['args'], (dict, tuple)):
                 message = obj['msg'] % obj['args']
             elif isinstance(obj['args'], list):
@@ -67,7 +67,7 @@ class Formatter:
             else:
                 message = obj['msg']
         else:
-            message = obj['msg']
+            message = obj['msg'].replace('%', '%%')
         clock = self._clock(obj['created'])
         colorPrefix = self._COLORS.get(obj['levelno'], '')
         formatted = self._logFormat % dict(


### PR DESCRIPTION
…that do not have arguments

@rom-stratoscale @alon-stratoscale @shimshon-stratoscale @eyal-stratoscale @idolivneh-stratoscale @roeih-stratoscale 

checked on random allocation while updating the egg in-place
will work with harbour as well (in case it'll happen there)

not sure to which branch to rebase it on